### PR TITLE
Fixes mix-it/linkit#6 : use full bootstrap js from CDN. 

### DIFF
--- a/app/views/main.html
+++ b/app/views/main.html
@@ -17,7 +17,7 @@
     <link rel="author" href="humans.txt"/>
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js" type="text/javascript"
             charset="${_response_encoding}"></script>
-    <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.1/js/bootstrap.min.js"></script>
+    <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js"></script>
     <script>
         $(function() {
             $("a[rel=twipsy]").tooltip({


### PR DESCRIPTION
We would have now to choose our path: full-CDN or locally served resources. Cos' now it's a kind of weird mix with old pages referencing not served bootstrap-v1 components. Old pages should be fucked up. I preferred not to touch them to keep a reference on their JS requirements (on Bootstrap v1 components) before refactoring them.
