### PR TITLE
Fixes mix-it/linkit#84 : no more headers "Développement" overlaps on iPhone

### DIFF
--- a/app/views/Application/index.html
+++ b/app/views/Application/index.html
@@ -144,7 +144,10 @@
     <div class="row headers big-icons-header" style="padding-top: 0px;">
         <div class="col-lg-12">
             <div>
-                <h1>&{'home.headers.development'}</h1>
+                <h1>
+                    <span class="hidden-xs">&{'home.headers.development'}</span>
+                    <span class="visible-xs">&{'home.headers.development.short'}</span>
+                </h1>
                 <i class="icon-keyboard"></i>
             </div>
             <div>

--- a/conf/messages
+++ b/conf/messages
@@ -56,6 +56,7 @@ tab.lasttalks=Dernières sessions
 tab.lastattendees=Derniers inscrits
 
 home.headers.development=Développement
+home.headers.development.short=Dev
 home.headers.agility=Agilité
 home.headers.innovation=Innovation
 home.speakers.previously=Précédemment, à Mix-IT

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -56,6 +56,7 @@ tab.lasttalks=Last talks
 tab.lastattendees=Last members
 
 home.headers.development=Development
+home.headers.development.short=Development
 home.headers.agility=Agility
 home.headers.innovation=Innovation
 home.speakers.previously=Previously, at Mix-IT


### PR DESCRIPTION
in French, "Développement" -> "dev" on `xs` device.
