### PR TITLE
Fixes mix-it/linkit#161 : Staff now can flag feedback on sessions

### DIFF
--- a/app/controllers/Sessions.java
+++ b/app/controllers/Sessions.java
@@ -17,6 +17,7 @@ import play.data.validation.Valid;
 import play.data.validation.Validation;
 import play.i18n.Messages;
 import play.libs.Images;
+import play.mvc.With;
 
 import java.util.*;
 
@@ -208,7 +209,7 @@ public class Sessions extends PageController {
         Logger.info("Session %s enregistrée", talk);
         show(talk.id, JavaExtensions.slugify(talk.title), true);
     }
-    
+
     public static void validate(long talkId) throws Throwable {
         Talk talk = Talk.findById(talkId);
         notFoundIfNull(talk);
@@ -217,13 +218,24 @@ public class Sessions extends PageController {
         talk.validate();
         show(talkId, JavaExtensions.slugify(talk.title), true);
     }
-    
+
     public static void unvalidate(long talkId) throws Throwable {
         Talk talk = Talk.findById(talkId);
         notFoundIfNull(talk);
         checkWriteAccess(talk);
 
         talk.unvalidate();
+        show(talkId, JavaExtensions.slugify(talk.title), true);
+    }
+
+    public static void feedback(long talkId, boolean feedback) throws Throwable {
+        Talk talk = Talk.findById(talkId);
+        notFoundIfNull(talk);
+        checkWriteAccess(talk);
+
+        talk.feedback = feedback;
+        talk.save();
+
         show(talkId, JavaExtensions.slugify(talk.title), true);
     }
 }

--- a/app/controllers/admin/AdminPlanning.java
+++ b/app/controllers/admin/AdminPlanning.java
@@ -1,6 +1,7 @@
 package controllers.admin;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
 import controllers.Check;
 import controllers.SecureLinkIt;
 import models.ConferenceEvent;
@@ -58,5 +59,23 @@ public class AdminPlanning extends Controller {
 
         PlanedSlot.save(planning);
         index();
+    }
+
+    public static void feedback() {
+        ConferenceEvent event = ConferenceEvent.CURRENT;
+        List<Talk> talks = Talk.findAllOn(event);
+
+        // Filter by feedback (old-school without FluentIterable)
+        List<Talk> talksWithFeedback = Lists.newArrayList();
+        List<Talk> talksWithoutFeedback = Lists.newArrayListWithExpectedSize(talks.size());
+        for (Talk talk : talks) {
+            if (talk.feedback) {
+                talksWithFeedback.add(talk);
+            } else {
+                talksWithoutFeedback.add(talk);
+            }
+        }
+
+        render(event, talksWithFeedback, talksWithoutFeedback);
     }
 }

--- a/app/models/Session.java
+++ b/app/models/Session.java
@@ -1,6 +1,7 @@
 package models;
 
 import com.google.common.base.Function;
+import com.google.common.base.Predicate;
 import controllers.Application;
 import controllers.Mails;
 import java.util.*;
@@ -89,6 +90,9 @@ public abstract class Session extends Model implements Lookable, Comparable<Sess
     @Enumerated(EnumType.STRING)
     @Required   // But nullable : must give language when editing, but not always given on old sessions.
     public TalkLanguage lang;
+
+    /* true if Staff has given feedback */
+    public boolean feedback;
 
     protected Session() {
         this.event = ConferenceEvent.CURRENT;

--- a/app/views/Sessions/show.html
+++ b/app/views/Sessions/show.html
@@ -67,7 +67,7 @@
                 #{/if}
                 <div class='alert-actions'>
                     <a class="btn btn-primary" href="@{Sessions.edit(talk.id)}">Editer</a>
-                #{if talk.valid}            
+                #{if talk.valid}
                     <a class="btn btn-danger" onclick="if (confirm('Voulez-vous vraiment invalider cette session?')) window.location='@{Sessions.unvalidate(talk.id)}';">Invalider</a>
                 #{/if}
                 #{else}
@@ -185,6 +185,21 @@
 </script>
         </div>
     </div>
+
+    #{secure.check models.Role.ADMIN_SESSION}
+    <div class="alert alert-info">
+        <p><strong>Staff : feedbacks</strong></p>
+        <div class='alert-actions'>
+            <a href="@{admin.AdminPlanning.feedback()}">Retour à la liste des feedbacks</a>
+            #{if talk.feedback}
+                <a class="btn btn-warning" href="@{Sessions.feedback(talk.id, false)}">Enlever feedback</a>
+            #{/if}
+            #{else}
+                <a class="btn btn-warning" href="@{Sessions.feedback(talk.id, true)}">Marquer feedback</a>
+            #{/else}
+        </div>
+    </div>
+    #{/secure.check}
 
     #{comments talk.comments, showPrivate:showPrivateComments /}
 

--- a/app/views/admin/AdminPlanning/feedback.html
+++ b/app/views/admin/AdminPlanning/feedback.html
@@ -1,0 +1,12 @@
+#{extends 'main.html' /}
+#{set title:'ADMIN - Feedback' /}
+
+<h1>Sessions sans feedback</h1>
+
+#{sessions sessions:talksWithoutFeedback, event:models.ConferenceEvent.CURRENT /}
+
+<hr/>
+
+<h1>Sessions avec feedback</h1>
+
+#{sessions sessions:talksWithFeedback, event:models.ConferenceEvent.CURRENT /}

--- a/app/views/main.html
+++ b/app/views/main.html
@@ -146,6 +146,7 @@
                     <li><a href="@{Articles.create()}">Créer un article</a></li>
                     <li><a href="@{Sessions.create()}">Créer une session</a></li>
                     <li class="divider"></li>
+                    <li><a href="@{admin.AdminPlanning.feedback()}">Feedbacks</a></li>
                     <li><a href="@{Interests.edit()}">Modérer les intérêts</a></li>
                     <li><a href="@{Operations.index()}">Opérations d'administration</a></li>
                     <li><a href="@{Mailings.index()}">Mailings</a></li>

--- a/app/views/tags/sessions.html
+++ b/app/views/tags/sessions.html
@@ -52,7 +52,7 @@
     }
 </script>
 
-<h1>&{'sessions.forEvent', _event}</h1>
+<h2>&{'sessions.forEvent', _event}</h2>
 
 #{if _sessions}
 

--- a/conf/routes
+++ b/conf/routes
@@ -10,6 +10,7 @@ GET     /                                       Application.index
 
 GET     /admin/planning                         admin.AdminPlanning.index
 POST    /admin/planning/save                    admin.AdminPlanning.save
+GET     /admin/feedback                         admin.AdminPlanning.feedback
 
 # Map static resources from the /app/public folder to the /public path
 GET     /public/                                staticDir:public

--- a/db/evolutions/17.sql
+++ b/db/evolutions/17.sql
@@ -1,0 +1,6 @@
+# --- !Ups
+alter table SESSION add column feedback bit default false;
+
+# --- !Downs
+alter table SESSION drop column feedback;
+


### PR DESCRIPTION
A new page Admin/Feedback lists sessions with/without feedback. On session detail, a new section is shown to staff, with a button for flagging.
