### PR TITLE
Disable (temporarily) mail notifications

### DIFF
--- a/app/controllers/JobCommentNotification.java
+++ b/app/controllers/JobCommentNotification.java
@@ -19,7 +19,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
-@Every("1min")
+// FIXME Restore notification after site migrated out of CloudBees
+// @Every("1min")
 public class JobCommentNotification extends BaseSinceLastTimeJob {
 
     public JobCommentNotification() {

--- a/app/controllers/JobFetchAllUsersTimelines.java
+++ b/app/controllers/JobFetchAllUsersTimelines.java
@@ -16,7 +16,7 @@ import play.jobs.Job;
  * Asynchronous fetch of user timelines on external providers (Google+, Twitter)
  * @author Sryl <cyril.lacote@gmail.com>
  */
-@Every("1h") // CLA 14/12/2011 : avoid Twitter blacklisting if we make more than 150 requests / hour
+@Every("1h")
 @NoTransaction
 public class JobFetchAllUsersTimelines extends Job {
 

--- a/app/controllers/JobNotificationsDaily.java
+++ b/app/controllers/JobNotificationsDaily.java
@@ -7,7 +7,8 @@ import play.jobs.On;
  * Asynchronous daily notifications of new activities
  * @author Sryl <cyril.lacote@gmail.com>
  */
-@On("0 0 2 * * ?")  // 2H du matin chaque jour
+// FIXME Restore notification after site migrated out of CloudBees
+// @On("0 0 2 * * ?")  // 2H du matin chaque jour
 public class JobNotificationsDaily extends BaseJobNotifications {
 
     public JobNotificationsDaily() {

--- a/app/controllers/JobNotificationsHourly.java
+++ b/app/controllers/JobNotificationsHourly.java
@@ -7,7 +7,8 @@ import play.jobs.Every;
  * Asynchronous "hourly" notifications of new activities
  * @author Sryl <cyril.lacote@gmail.com>
  */
-@Every("1h")
+// FIXME Restore notification after site migrated out of CloudBees
+// @Every("1h")
 public class JobNotificationsHourly extends BaseJobNotifications {
 
     public JobNotificationsHourly() {

--- a/app/controllers/JobNotificationsInstant.java
+++ b/app/controllers/JobNotificationsInstant.java
@@ -7,7 +7,8 @@ import play.jobs.Every;
  * Asynchronous "instant" notifications of new activities (actually, every 5 minutes...)
  * @author Sryl <cyril.lacote@gmail.com>
  */
-@Every("5min")
+// FIXME Restore notification after site migrated out of CloudBees
+// @Every("5min")
 public class JobNotificationsInstant extends BaseJobNotifications {
 
     public JobNotificationsInstant() {

--- a/app/controllers/JobNotificationsWeekly.java
+++ b/app/controllers/JobNotificationsWeekly.java
@@ -7,7 +7,8 @@ import play.jobs.On;
  * Asynchronous daily notifications of new activities
  * @author Sryl <cyril.lacote@gmail.com>
  */
-@On("0 0 1 ? * MON")  // 1H du matin tous les lundi matin
+// FIXME Restore notification after site migrated out of CloudBees
+// @On("0 0 1 ? * MON")  // 1H du matin tous les lundi matin
 public class JobNotificationsWeekly extends BaseJobNotifications {
 
     public JobNotificationsWeekly() {


### PR DESCRIPTION
To avoid double-post during migration, when hosted on both CloudBees and CloudFoundry.
poke @sdeleuze.
