### PR TITLE
Fix mix-it/linkit#325: private comment by default

### DIFF
--- a/app/views/Sessions/show.html
+++ b/app/views/Sessions/show.html
@@ -223,7 +223,7 @@
                             <div class="col-md-offset-2 col-md-10">
                                 <div class="checkbox">
                                     <label>
-                                        <input id="${field.id}" name="${field.name}" type="checkbox" >
+                                        <input id="${field.id}" name="${field.name}" type="checkbox" #{if showPrivateComments}checked="checked"#{/if} >
                                         &{field.name}
                                     </label>
                                 </div>


### PR DESCRIPTION
 For Staff and Speaker of their talk (i.e the only members able to post private comment on a session), comments are private by default.