### PR TITLE
Exports of session proposals are now ordered by id.

### DIFF
--- a/app/controllers/Exports.java
+++ b/app/controllers/Exports.java
@@ -16,12 +16,12 @@ public class Exports extends PageController {
     }
 
     public static void exportSessions() {
-        List<Talk> talks = Talk.find("valid = false and event = ? order by track, title", ConferenceEvent.CURRENT).fetch();
+        List<Talk> talks = Talk.find("valid = false and event = ? order by id", ConferenceEvent.CURRENT).fetch();
         render(talks);
     }
 
     public static void exportSessionsCSV() {
-        List<Session> sessions = Talk.find("event = ? order by format, title", ConferenceEvent.CURRENT).fetch();
+        List<Session> sessions = Talk.find("event = ? order by id", ConferenceEvent.CURRENT).fetch();
         renderTemplate("Exports/sessions.csv", sessions);
     }
 


### PR DESCRIPTION
 Respect chronological order, and enable to print only latest new proposals.
Should please @javamind.

Fix #335.