### PR TITLE
Remove Member.links from JSON, to try to avoid circular references

### DIFF
--- a/app/controllers/api/AbstractMemberJsonSerializer.java
+++ b/app/controllers/api/AbstractMemberJsonSerializer.java
@@ -30,12 +30,6 @@ public abstract class AbstractMemberJsonSerializer {
         result.addProperty("urlimage", member.getUrlImage());
         result.addProperty("nbConsults", member.nbConsults);
 
-        if (CollectionUtils.size(member.links) != 0) {
-            result.add("links", JSON.toJsonArrayOfIds(member.links));
-        }
-        if (CollectionUtils.size(member.linkers) != 0) {
-            result.add("linkers", JSON.toJsonArrayOfIds(member.linkers));
-        }
         if (CollectionUtils.size(member.sharedLinks) != 0) {
             result.add("sharedLinks", jsonSerializationContext.serialize(member.sharedLinks));
         }


### PR DESCRIPTION
I don't see how there can by a circular reference on `Member.links`, as traced in #351.
It's like our custom JSON serializer `MemberJsonSerializer` was not used since running on CloudFoundry.

It here tried to remove any serialization of `Member.links` (which is probably useless to any mobile app), to see if it fixes the problem. But I'm not very confident...

Fix #351 ?