### PR TITLE
DB Conf: set DB connection pool max size to 15

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -141,6 +141,8 @@ db.url=jdbc:h2:mem:play;MODE=MYSQL;MVCC=TRUE;LOCK_TIMEOUT=25000
 # generic "destroy" method :
 # db.destroyMethod=close
 
+db.pool.maxSize=15
+
 # JPA Configuration (Hibernate)
 # ~~~~~
 #


### PR DESCRIPTION
That's our ClearDB `maxConnections` configuration via CloudFoundry.
Hopefully this will stop our frequent app crashes when crawlers come to slurp our site.

cc @sdeleuze.