### PR TITLE
refs #293 : print CSS for planing page - new adjustments

### DIFF
--- a/app/views/Sessions/planning.html
+++ b/app/views/Sessions/planning.html
@@ -21,24 +21,20 @@
 
         body {
             padding-top: 0px ;
-            font-size: 12px;
+            font-size: 5pt;
         }
         h1:before {
             content: url(@{'/public/images/mini-mixit.png'});
-            margin-right: 2em;
+            margin-right: 10pt;
         }
         h1 {
-            font-size: 24px;
+            font-size: 20pt;
             text-align: center;
         }
         .page-break {
             page-break-before: always;
         }
-        .container {
-            max-width: 1500px;
-        }
         a[href]:after { display:none; }
-        i.star {display:none;}
 
         .session br {
             display:none;


### PR DESCRIPTION
The page should now print by default on an A4 paper.
Favorites stars added on print